### PR TITLE
appctl-1.0.5: support custom checkSvc

### DIFF
--- a/appctl/files/opt/app/bin/ctl.sh
+++ b/appctl/files/opt/app/bin/ctl.sh
@@ -118,7 +118,7 @@ initSvc() {
   systemctl unmask -q ${1%%/*}
 }
 
-checkSvc() {
+_checkSvc() {
   checkActive ${1%%/*} || {
     log "Service '$1' is inactive."
     return $EC_CHECK_INACTIVE
@@ -159,13 +159,13 @@ _initNode() {
 
 _revive() {
   local svc; for svc in $(getServices); do
-    checkSvc $svc || restartSvc $svc || log "ERROR: failed to restart '$svc' ($?)."
+    execute checkSvc $svc || restartSvc $svc || log "ERROR: failed to restart '$svc' ($?)."
   done
 }
 
 _check() {
   local svc; for svc in $(getServices); do
-    checkSvc $svc
+    execute checkSvc $svc
   done
 }
 

--- a/appctl/meta/main.yml
+++ b/appctl/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   role_name: appctl
-  role_version: 1.0.4
+  role_version: 1.0.5
   author: Hongliang Wang
   description: installs appctl
 


### PR DESCRIPTION
Health checks include two parts:
- systemctl is-active $svc
- check endpoints, e.g. tcp:2181, http:80

Sometimes we'd like include additional checks to ensure the service is not false-positive.