### PR TITLE
appctl-1.0.7: fix revive issue

### DIFF
--- a/appctl/meta/main.yml
+++ b/appctl/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   role_name: appctl
-  role_version: 1.0.6
+  role_version: 1.0.7
   author: Hongliang Wang
   description: installs appctl
 


### PR DESCRIPTION
Sometimes, the previous `execute` function behaves unexpectedly:

  revive() {
    execute checkSvc $svc || execute restart $svc
  }

This may caused by multiple chained `execute` like:

  funcA() {
    execute funcB || execute funcC
  }

  execute funcA

So we removed `execute` and use stupid declared functions to reduce complexity.